### PR TITLE
postmarketos-base-ui: enable NetworkManager USB tethering

### DIFF
--- a/main/postmarketos-base-ui/APKBUILD
+++ b/main/postmarketos-base-ui/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Clayton Craft <clayton@craftyguy.net>
 pkgname=postmarketos-base-ui
-pkgver=4
-pkgrel=3
+pkgver=5
+pkgrel=0
 pkgdesc="Meta package for minimal postmarketOS UI base"
 url="https://postmarketos.org"
 arch="noarch"
@@ -37,6 +37,8 @@ replaces_priority=100  # leave plenty for alpine
 
 _source644="
 	etc/NetworkManager/conf.d/hostname-mode.conf
+	etc/NetworkManager/conf.d/usb-ethernet.conf
+	etc/NetworkManager/system-connections/usb-ethernet.nmconnection
 	etc/chrony/chrony.conf
 	etc/conf.d/tinydm
 	etc/conf.d/wpa_supplicant
@@ -118,11 +120,17 @@ _obexd() {
 
 networkmanager() {
 	install_if="$pkgname=$pkgver-r$pkgrel networkmanager"
+	install="$subpkgname.pre-upgrade $subpkgname.post-install"
+	depends="dnsmasq"
 	amove etc/NetworkManager/conf.d/hostname-mode.conf
+	amove etc/NetworkManager/conf.d/usb-ethernet.conf
+	amove etc/NetworkManager/system-connections/usb-ethernet.nmconnection
 }
 
 sha512sums="
 3c9ae7415f4891bee8595166ed6a42cb577a837f741c6b5409d193558626348b41516888a01d0c4895282c5f4e9a1ff838c19712888750b2ef68429bb4b42ee3  rootfs-etc-NetworkManager-conf.d-hostname-mode.conf
+d19ceea8844b54e8a027a6131fc1c014e08a7b69e7c9c5fe30f836b097521a4e95951a868e9ccf07d38780abcf7578a3e1820e6f2eb15ccc8ea376f9c1091e7f  rootfs-etc-NetworkManager-conf.d-usb-ethernet.conf
+f3e5a38fd3c38f5026254bc7d8e20ffabc32afc70c4124356f8f6362d3dbce9b59a9e4fc9b9afd070f73424e05802e7b664986f91bde6e6ba3cb62a68f621ef1  rootfs-etc-NetworkManager-system-connections-usb-ethernet.nmconnection
 e5d049db1d82c510bab9246208b51b8ec2711d008d67792fc10d4c0b65ed4dece7b5ae3c3dd28a8539d177b6849c1f921cb9fef3d2c7bee0355451f7b4757ec6  rootfs-etc-chrony-chrony.conf
 44e4283c6f77de83915977dd3bc2d8e2d96b3ed6cc68d3cc156304359ae649b5a8b0bac843e517ec6faa2066dd43ba85e313899b1eda04862f864fb9eb508aa0  rootfs-etc-conf.d-tinydm
 fe0651904c1f40ffa67d83daca190af199f63247e53642a59a1e1147cd06776fcf20b7b2fcc5373783d50b8bd6ce8d1354c8e5f4d582d319727b9ceefd1e8e16  rootfs-etc-conf.d-wpa_supplicant

--- a/main/postmarketos-base-ui/postmarketos-base-ui-networkmanager.post-install
+++ b/main/postmarketos-base-ui/postmarketos-base-ui-networkmanager.post-install
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+# Enable dnsmasq for DNS queries when USB tethering is enabled
+rc-update -q add dnsmasq default
+
+return 0

--- a/main/postmarketos-base-ui/postmarketos-base-ui-networkmanager.pre-upgrade
+++ b/main/postmarketos-base-ui/postmarketos-base-ui-networkmanager.pre-upgrade
@@ -1,0 +1,1 @@
+postmarketos-base-ui-networkmanager.post-install

--- a/main/postmarketos-base-ui/rootfs-etc-NetworkManager-conf.d-usb-ethernet.conf
+++ b/main/postmarketos-base-ui/rootfs-etc-NetworkManager-conf.d-usb-ethernet.conf
@@ -1,0 +1,8 @@
+# Do not make automatically connections for USB RDNIS on boot otherwise we get duplicates
+[main]
+no-auto-default=usb0
+
+# USB gadget devices are not managed by default, override that behavior for our USB RDNIS
+[device-usb0]
+match=interface-name:usb0
+managed=true

--- a/main/postmarketos-base-ui/rootfs-etc-NetworkManager-system-connections-usb-ethernet.nmconnection
+++ b/main/postmarketos-base-ui/rootfs-etc-NetworkManager-system-connections-usb-ethernet.nmconnection
@@ -1,0 +1,20 @@
+[connection]
+id=USB Ethernet
+uuid=dde62d4c-55de-4740-88a2-8917f029ffdc
+type=ethernet
+autoconnect=false
+interface-name=usb0
+timestamp=1658307039
+
+[ethernet]
+mac-address=0A:61:2B:C6:70:59
+
+[ipv4]
+address1=172.16.42.1/16
+method=manual
+
+[ipv6]
+addr-gen-mode=stable-privacy
+method=link-local
+
+[proxy]


### PR DESCRIPTION
Configure NetworkManager to manage our USB gadget as an Ethernet device to allow USB tethering through NetworkManager. Only tested with nmcli since UIs such as GNOME Control Center do not properly resize yet.

This commit adds the following:

1. Add a NetworkManager configuration to manage usb0 because NetworkManager marks USB gadgets by default unmanaged through one of its provided udev rules in /lib/udev/rules/85-nm-unmanaged.rules
2. Forbid NetworkManager to create connection profiles for usb0 on boot since we provide our own profile. If we do not set this option, we get 2 profiles on boot for the same usb0 interface with the same name but different UUID.
3. Enable dnsmasq as a service to provide DNS lookups to connected devices over USB tethering. Normally, NetworkManager does that automatically, but it cannot start dnsmasq as it enables DHCP in dnsmasq as well which conflicts with unudphcd. Therefore, add dnsmasq as a service in DNS-only mode (its default).

This only takes effect when the UI depends on NetworkManager.