### PR TITLE
main/postmarketos-ui-{mate,xfce4}: disable lightdm service on upgrade

### DIFF
--- a/main/postmarketos-ui-mate/APKBUILD
+++ b/main/postmarketos-ui-mate/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Jakko <jahau@rocketmail.com>
 pkgname=postmarketos-ui-mate
 pkgver=6
-pkgrel=0
+pkgrel=1
 pkgdesc="(X11) MATE Desktop Environment, fork of GNOME2 (stylus recommended)"
 url="http://mate-desktop.org/"
 arch="noarch"

--- a/main/postmarketos-ui-mate/postmarketos-ui-mate.post-install
+++ b/main/postmarketos-ui-mate/postmarketos-ui-mate.post-install
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+rc-update del lightdm default
+
 rc-update add bluetooth default
 rc-update add networkmanager default
 rc-update add tinydm default

--- a/main/postmarketos-ui-xfce4/APKBUILD
+++ b/main/postmarketos-ui-xfce4/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Jakko <jahau@rocketmail.com>
 pkgname=postmarketos-ui-xfce4
 pkgver=0.5.1
-pkgrel=10
+pkgrel=11
 pkgdesc="(X11) Lightweight desktop (stylus recommended)"
 url="https://gitlab.com/postmarketOS/xfce4-phone"
 arch="noarch"

--- a/main/postmarketos-ui-xfce4/postmarketos-ui-xfce4.post-install
+++ b/main/postmarketos-ui-xfce4/postmarketos-ui-xfce4.post-install
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+rc-update del lightdm default
+
 rc-update add bluetooth default
 rc-update add networkmanager default
 rc-update add tinydm default


### PR DESCRIPTION
In 2c5c22f3e3a7c3e647b9948ca02456d0a7661b4c and
5915d1630b0b85e6ac657b4bbfdb1a9dc1031d51 LightDM was replaced for tinydm, but the LightDM service was never actually disabled. So now weird things are happening and 2 DM's are running at the same time.