### PR TITLE
main/postmarketos-base-ui: enable USB tethering

### DIFF
--- a/.ci/shellcheck.sh
+++ b/.ci/shellcheck.sh
@@ -18,6 +18,7 @@ sh_files="
 	./main/osk-sdl/unlock.sh
 	./main/postmarketos-base/rootfs-usr-lib-firmwareload.sh
 	./main/postmarketos-base-ui/rootfs-etc-NetworkManager-dispatcher.d-99-dns-filter.sh
+	./main/postmarketos-base-ui/rootfs-etc-NetworkManager-dispatcher.d-85-tethering
 	./main/postmarketos-installkernel/installkernel-pmos
 	./main/postmarketos-initramfs/init.sh
 	./main/postmarketos-initramfs/init_functions.sh

--- a/main/postmarketos-base-ui/APKBUILD
+++ b/main/postmarketos-base-ui/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Clayton Craft <clayton@craftyguy.net>
 pkgname=postmarketos-base-ui
-pkgver=8
+pkgver=9
 pkgrel=0
 pkgdesc="Meta package for minimal postmarketOS UI base"
 url="https://postmarketos.org"
@@ -40,6 +40,7 @@ replaces_priority=100  # leave plenty for alpine
 _source644="
 	etc/NetworkManager/conf.d/hostname-mode.conf
 	etc/NetworkManager/conf.d/use-dnsmasq.conf
+	etc/NetworkManager/conf.d/tethering.conf
 	etc/chrony/chrony.conf
 	etc/conf.d/openrc-settingsd
 	etc/conf.d/tinydm
@@ -50,8 +51,12 @@ _source644="
 	etc/sleep-inhibitor.conf
 	etc/X11/Xwrapper.config
 	"
+_source600="
+	usr/lib/NetworkManager/system-connections/USB_Networking.nmconnection
+"
 _source755="
 	etc/NetworkManager/dispatcher.d/99-dns-filter.sh
+	etc/NetworkManager/dispatcher.d/85-tethering
 	etc/tinydm.d/env-wayland.d/50-firefox-wayland.sh
 	etc/tinydm.d/env-wayland.d/50-sdl-wayland.sh
 	"
@@ -63,12 +68,15 @@ flatpath() {
 		echo "rootfs-$i" | sed s./.-.g
 	done
 }
-source="$(flatpath $_source644 $_source755)"
+source="$(flatpath $_source644 $_source600 $_source755)"
 
 package() {
 	local i
 	for i in $_source644; do
 		install -Dm644 "$srcdir/$(flatpath "$i")" "$pkgdir/$i"
+	done
+	for i in $_source600; do
+		install -Dm600 "$srcdir/$(flatpath "$i")" "$pkgdir/$i"
 	done
 	for i in $_source755; do
 		install -Dm755 "$srcdir/$(flatpath "$i")" "$pkgdir/$i"
@@ -139,9 +147,11 @@ networkmanager() {
 		networkmanager-openrc
 		networkmanager-tui
 		networkmanager-wifi
-		networkmanager-wwan"
-
+		networkmanager-wwan
+		networkmanager-dnsmasq"
 	amove etc/NetworkManager/conf.d/hostname-mode.conf
+	amove etc/NetworkManager/dispatcher.d/85-tethering
+	amove usr/lib/NetworkManager/system-connections/USB_Networking.nmconnection
 	amove etc/NetworkManager/conf.d/use-dnsmasq.conf
 	amove etc/NetworkManager/dispatcher.d/99-dns-filter.sh
 }
@@ -156,6 +166,7 @@ _default_camera() {
 sha512sums="
 3c9ae7415f4891bee8595166ed6a42cb577a837f741c6b5409d193558626348b41516888a01d0c4895282c5f4e9a1ff838c19712888750b2ef68429bb4b42ee3  rootfs-etc-NetworkManager-conf.d-hostname-mode.conf
 900554534191fa0797064d35350934cdd8af59f30f0ae7d8ec63c2e11c44a16c643d3024b6543940488cd590fec1d392548bcaacc3be88cddff90f69b17ece07  rootfs-etc-NetworkManager-conf.d-use-dnsmasq.conf
+6507eb31cdd694a7db0280246433118a650bf5d99fbe639f967ae2d95945429a7e03ca6feb5bb6e7b9fb14fcec21e13e51209a79edd0041e77b5bf76b129ed6f  rootfs-etc-NetworkManager-conf.d-tethering.conf
 e5d049db1d82c510bab9246208b51b8ec2711d008d67792fc10d4c0b65ed4dece7b5ae3c3dd28a8539d177b6849c1f921cb9fef3d2c7bee0355451f7b4757ec6  rootfs-etc-chrony-chrony.conf
 49fb494b659fe0149a93eafe109609acce6a470bb8acea160638d07e0e4b11af2544f34549d5ef2deb2914a7ef13d0d470b04ad62981f14f96999af02a5f24cf  rootfs-etc-conf.d-openrc-settingsd
 44e4283c6f77de83915977dd3bc2d8e2d96b3ed6cc68d3cc156304359ae649b5a8b0bac843e517ec6faa2066dd43ba85e313899b1eda04862f864fb9eb508aa0  rootfs-etc-conf.d-tinydm
@@ -165,7 +176,9 @@ fe0651904c1f40ffa67d83daca190af199f63247e53642a59a1e1147cd06776fcf20b7b2fcc53737
 90b30cbea660ef6cd4c0461b6935de0cd63a84a1a40edb24348a83044c97935b974bd8bafda9cd558e92d3eb69e22c5ccf55483b80f839e24f0eb57ae2df6fe3  rootfs-etc-skel-.profile
 6b9c7bb73213187eb9ca8a94109b2b816f50c1158c90fec2e92b373864280d67741589e5bfbab8810945f031d2f4b535aad78a72e46e52ea50be5b85324da381  rootfs-etc-sleep-inhibitor.conf
 cac604e25c46e695dd30bd5a10cfd2d69595fcc3bc290096ac94b76b10834d591ea6576afb79c46b5da492a1dbf8660cf87b6110cd39937e15237bc74fa7a5c6  rootfs-etc-X11-Xwrapper.config
+1b8add60574ec4644197cb93263c0653325c2e88e03673de918be5fb3280c7b81e8e97dce498850a07f2f3307771c44f3c876922e5cbd5207523ede31816296f  rootfs-usr-lib-NetworkManager-system-connections-USB_Networking.nmconnection
 52d58729cbf3cd0318de633e8a8da74c7af246025a8c5746d5e7c854bdabbf27fa07d8558ffec92a30491cdb687fe4414de5adcddd7da5be3510f918fba463a2  rootfs-etc-NetworkManager-dispatcher.d-99-dns-filter.sh
+b344a64619aac5295342c597087ecf0614d4dfa0f7afd51f71dd2e9abc473ab9d08b22b3c075729e2f5e69f4e0e601ed3a9b76886c805650e02d6cc4643a7280  rootfs-etc-NetworkManager-dispatcher.d-85-tethering
 d1ddd43489e6016e3ffd716027ed2bae4a2ab5f213118bdbcb96750e267ab7c0367cd0e0e386300aa5550352653144f5caeddd790621fe0879f83ca1995bb65c  rootfs-etc-tinydm.d-env-wayland.d-50-firefox-wayland.sh
 ecaa57d033a119a53a6574c27636b7c89d659d75ea48a973a6a4ff6f90e5d07202529fd489bfc9dfc7430f5b60f40612f6d5c06f7fab47e681b0a3112a874058  rootfs-etc-tinydm.d-env-wayland.d-50-sdl-wayland.sh
 "

--- a/main/postmarketos-base-ui/rootfs-etc-NetworkManager-conf.d-tethering.conf
+++ b/main/postmarketos-base-ui/rootfs-etc-NetworkManager-conf.d-tethering.conf
@@ -1,0 +1,10 @@
+[main]
+# Do not auto-generate connections for usb0 iface
+no-auto-default=usb0
+
+# USB gadgets are not managed by default, make exception for usb0 iface
+# Iface is configured in initfs, do not persist its NetworkManager connection
+[device-usb0]
+match-device=interface-name:usb0
+managed=true
+keep-configuration=no

--- a/main/postmarketos-base-ui/rootfs-etc-NetworkManager-dispatcher.d-85-tethering
+++ b/main/postmarketos-base-ui/rootfs-etc-NetworkManager-dispatcher.d-85-tethering
@@ -1,0 +1,119 @@
+#!/bin/sh -e
+# Handle USB tethering with unudhcpd and NetworkManager while also
+# keeping SSH login over USB working when tethering is disabled.
+#
+# Copyright (c) 2023 Dylan Van Assche
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Must match with the supplied connection profile,
+# using UUID allows the user to change the connection name if they want to.
+con_uuid="83bd1823-feca-4c2b-9205-4b83dc792e1f"
+interface="usb0"
+host_ip="172.16.42.1"
+client_ip="172.16.42.2"
+
+# Skip if iface does not match
+if [ "$DEVICE_IFACE" != "$interface" ]; then
+	exit 0
+fi
+
+# Trigger a disconnect/connect event on the client side to request a new DHCP lease.
+reactivate_gadget() {
+	# Mount configFS
+	mkdir -p /config
+	mount -t configfs none /config || true
+
+	logger -t nm-tethering "configFS mounted"
+
+	# Reactivate gadget
+	udc=$(cat /config/usb_gadget/g1/UDC)
+	echo "" > /config/usb_gadget/g1/UDC
+	sleep 1
+	echo "$udc" > /config/usb_gadget/g1/UDC
+
+	logger -t nm-tethering "gadget reactivated"
+
+	# Unmount configFS
+	umount /config
+	rm -rf /config
+
+	logger -t nm-tethering "configFS unmounted"
+}
+
+# Default static IP for SSH acccess
+# 1. Configure NetworkManager connection to use IP 172.16.42.1, same as initfs.
+# 2. Disable IPv6 as unudhcpd only supplies IPv4 addresses.
+# 3. Start unudhcpd to handle DHCP requests.
+# 4. Reactivate the USB Ethernet gadget to force the clients to reactivate the interface.
+disable_tethering() {
+	# Configure static IP and bring up connection automatically
+	nmcli connection modify "$con_uuid" ipv4.address "$host_ip/16"
+	nmcli connection modify "$con_uuid" ipv4.method "manual"
+	nmcli connection modify "$con_uuid" ipv6.method "link-local"
+	nmcli connection modify "$con_uuid" connection.autoconnect "true"
+
+	# If unudhpcd is not running, start it and configure it similar to initfs
+	if [ ! "$(pidof unudhcpd)" ]; then
+		(unudhcpd -i "$interface" -s "$host_ip" -c "$client_ip") &
+		logger -t nm-tethering "unudhcpd started"
+
+		reactivate_gadget
+		logger -t nm-tethering "USB tethering disabled"
+	fi
+
+}
+
+# USB tethering
+# 1. Enforce 172.16.42.1 as host IP even in tethering mode.
+# 2. Stop unudhcpd as NetworkManager will spawn dnsmasq to handle DNS and DHCP requests.
+# 3. Reactivate the USB Ethernet gadget to force the clients to reactivate the interface.
+enable_tethering() {
+	# Enforce the same IP range as when tethering is disabled, this will retrigger
+	# the script as we have to reapply again, also bring up connection automatically.
+	ip=$(nmcli connection show "$con_uuid" --active | grep ipv4.addresses | tr -s " " | cut -d " " -f2)
+	if [ "$ip" != "$host_ip/16" ]; then
+		logger -t nm-tethering "Enforcing $host_ip/16 as DHCP range"
+		nmcli connection modify "$con_uuid" ipv4.address "$host_ip/16"
+		nmcli connection modify "$con_uuid" connection.autoconnect "true"
+		nmcli device reapply "$interface"
+		return
+	fi
+
+	# Kill unudhcpd if needed
+	if [ "$(pidof unudhcpd)" ]; then
+		killall unudhcpd
+		logger -t nm-tethering "unudhcpd stopped"
+
+		reactivate_gadget
+		logger -t nm-tethering "USB tethering enabled"
+	fi
+
+}
+
+# Handle dispatcher events for tethering
+method=$(nmcli connection show "$con_uuid" --active | grep ipv4.method | tr -s " " | cut -d " " -f2)
+case $NM_DISPATCHER_ACTION in
+	# Always disable tethering on insert or removal for security
+	"up"|"down")
+		disable_tethering
+
+		# The connection may have been configured before to tethering which
+		# is not desired when iface comes up or is shut down as tethering must be
+		# disabled. Enforce this by triggering a reapply after modifying the connection
+		# which will cause NetworkManager to trigger the script again.
+		# If the iface is already down since dispatcher scripts are executed async,
+		# the command will fail which is fine to ignore
+		if [ "$method" = "shared" ]; then
+			logger -t nm-tethering "Enforcing tethering disabled on iface up/down"
+			nmcli device reapply "$interface" || true
+		fi
+		;;
+	# Enable tethering if the user explicitly enabled it
+	"reapply")
+		if [ "$method" = "shared" ]; then
+			enable_tethering
+		elif [ "$method" = "manual" ]; then
+			disable_tethering
+		fi
+		;;
+esac

--- a/main/postmarketos-base-ui/rootfs-usr-lib-NetworkManager-system-connections-USB_Networking.nmconnection
+++ b/main/postmarketos-base-ui/rootfs-usr-lib-NetworkManager-system-connections-USB_Networking.nmconnection
@@ -1,0 +1,17 @@
+[connection]
+id=USB Networking
+uuid=83bd1823-feca-4c2b-9205-4b83dc792e1f
+type=ethernet
+interface-name=usb0
+
+[ethernet]
+
+[ipv4]
+address1=172.16.42.1/16
+method=manual
+
+[ipv6]
+addr-gen-mode=default
+method=link-local
+
+[proxy]


### PR DESCRIPTION
USB tethering allows users to use their phone's WiFi or WWAN interface as an access point for the device they connect the phone with over USB. This way, they can use their data plan with a laptop or desktop when regular Internet access is absent.

Configure NetworkManager to manage the usb0 iface from initfs so users can configure it in GNOME Settings or KDE. Include a NetworkManager dispatcher script as well to handle postmarketOS' setup with unudhcpd as we want to provide an SSH login over USB when tethering is disabled. If tethering is enabled, unudhpcd is stopped and its functionality is taken over by NetworkManager through an instance of dnsmasq. NetworkManager will also configure the necessary settings to allow IP forwarding and firewall rules during tethering. Once disabled, NetworkManager cleans up these settings and our dispatcher script starts unudhcpd again.

Due to upstream changes, NetworkManager requires networkmanager-dnsmasq subpackage as dependency as dnsmasq needs DBus support for NetworkManager. Without it, NetworkManager will silently fail spawning dnsmasq instances.